### PR TITLE
Fix tekton error

### DIFF
--- a/tekton/pipeline.yaml
+++ b/tekton/pipeline.yaml
@@ -36,3 +36,17 @@ spec:
         value: $(params.branch)
       runAfter:
         - init
+
+    - name: lint
+      workspaces:
+        - name: source
+          workspace: pipeline-workspace
+      taskRef:
+        name: flake8
+      params:
+      - name: image
+        value: "python:3.9-slim"
+      - name: args
+        value: ["--count","--max-complexity=10","--max-line-length=127","--statistics"]
+      runAfter:
+        - clone

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -21,6 +21,7 @@ DATABASE_URI = os.getenv(
 BASE_URL = "/accounts"
 HTTPS_ENVIRON = {'wsgi.url_scheme': 'https'}
 
+
 ######################################################################
 #  T E S T   C A S E S
 ######################################################################
@@ -36,7 +37,6 @@ class TestAccountService(TestCase):
         app.logger.setLevel(logging.CRITICAL)
         init_db(app)
         talisman.force_https = False
-
 
     @classmethod
     def tearDownClass(cls):
@@ -188,10 +188,11 @@ class TestAccountService(TestCase):
         }
         for key, value in headers.items():
             self.assertEqual(response.headers.get(key), value)
-            
+
     def test_cors_security(self):
         """It should return a CORS header"""
         response = self.client.get('/', environ_overrides=HTTPS_ENVIRON)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         # Check for the CORS header
         self.assertEqual(response.headers.get('Access-Control-Allow-Origin'), '*')
+        


### PR DESCRIPTION
This pull request introduces a new linting step to the Tekton pipeline and includes some minor formatting updates in the test suite. The linting step will help ensure code quality by running `flake8` checks as part of the CI/CD workflow.

**CI/CD Pipeline Enhancements:**

* Added a new `lint` step to `tekton/pipeline.yaml` that runs `flake8` with specific arguments after the `clone` step, using a Python 3.9 image. This enforces code style and complexity checks during the pipeline.

**Test Suite Formatting:**

* Added a blank line before the test cases section in `tests/test_routes.py` for improved readability.
* Removed an unnecessary blank line after disabling HTTPS enforcement in the `setUpClass` method.
* Added a trailing blank line at the end of the `test_cors_security` method for consistency.